### PR TITLE
feat: add config for ignoring SSL cert verification failures

### DIFF
--- a/config.dist.yml
+++ b/config.dist.yml
@@ -5,6 +5,7 @@ timeout: "10s"
 check_interval: "30s"
 log_level: "error"
 log_format: "fmt"
+ignore_ssl_verify: "false"
 targets: []
 #  - name: "website"
 #    type: "http"

--- a/config.dist.yml
+++ b/config.dist.yml
@@ -5,7 +5,7 @@ timeout: "10s"
 check_interval: "30s"
 log_level: "error"
 log_format: "fmt"
-ignore_ssl_verify: "false"
+insecure_skip_ssl_verify: "false"
 targets: []
 #  - name: "website"
 #    type: "http"

--- a/config.go
+++ b/config.go
@@ -15,17 +15,16 @@ const defaultLogLevel = "error"
 const defaultLogFormat = "fmt"
 const targetTypeHTTP = "http"
 const targetTypeTCP = "tcp"
-const defaultIgnoreSSL = false
 
 type Config struct {
-	ListenAddr    string        `yaml:"listen_addr,omitempty"`
-	TorAddr       string        `yaml:"tor_addr,omitempty"`
-	Timeout       time.Duration `yaml:"timeout,omitempty"`
-	CheckInterval time.Duration `yaml:"check_interval,omitempty"`
-	LogLevel      string        `yaml:"log_level"`
-	LogFormat     string        `yaml:"log_format"`
-	Targets       []Target      `yaml:"targets,omitempty"`
-	IgnoreSSL     bool          `yaml:"ignore_ssl_verify"`
+	ListenAddr         string        `yaml:"listen_addr,omitempty"`
+	TorAddr            string        `yaml:"tor_addr,omitempty"`
+	Timeout            time.Duration `yaml:"timeout,omitempty"`
+	CheckInterval      time.Duration `yaml:"check_interval,omitempty"`
+	LogLevel           string        `yaml:"log_level"`
+	LogFormat          string        `yaml:"log_format"`
+	Targets            []Target      `yaml:"targets,omitempty"`
+	InsecureSkipVerify bool          `yaml:"insecure_skip_ssl_verify"`
 }
 
 type Target struct {
@@ -36,13 +35,13 @@ type Target struct {
 
 func NewConfig() *Config {
 	return &Config{
-		ListenAddr:    defaultListenAddr,
-		TorAddr:       defaultTorAddr,
-		Timeout:       defaultTimeout,
-		CheckInterval: defaultCheckInterval,
-		LogLevel:      defaultLogLevel,
-		LogFormat:     defaultLogFormat,
-		IgnoreSSL:     defaultIgnoreSSL,
+		ListenAddr:         defaultListenAddr,
+		TorAddr:            defaultTorAddr,
+		Timeout:            defaultTimeout,
+		CheckInterval:      defaultCheckInterval,
+		LogLevel:           defaultLogLevel,
+		LogFormat:          defaultLogFormat,
+		InsecureSkipVerify: false,
 	}
 }
 

--- a/config.go
+++ b/config.go
@@ -15,6 +15,7 @@ const defaultLogLevel = "error"
 const defaultLogFormat = "fmt"
 const targetTypeHTTP = "http"
 const targetTypeTCP = "tcp"
+const defaultIgnoreSSL = false
 
 type Config struct {
 	ListenAddr    string        `yaml:"listen_addr,omitempty"`
@@ -24,6 +25,7 @@ type Config struct {
 	LogLevel      string        `yaml:"log_level"`
 	LogFormat     string        `yaml:"log_format"`
 	Targets       []Target      `yaml:"targets,omitempty"`
+	IgnoreSSL     bool          `yaml:"ignore_ssl_verify"`
 }
 
 type Target struct {
@@ -40,6 +42,7 @@ func NewConfig() *Config {
 		CheckInterval: defaultCheckInterval,
 		LogLevel:      defaultLogLevel,
 		LogFormat:     defaultLogFormat,
+		IgnoreSSL:     defaultIgnoreSSL,
 	}
 }
 

--- a/main.go
+++ b/main.go
@@ -1,6 +1,7 @@
 package main
 
 import (
+	"crypto/tls"
 	"flag"
 	"net/http"
 	"net/url"
@@ -89,6 +90,9 @@ func checkHTTP(target Target, wg *sync.WaitGroup) {
 	}
 
 	transport := &http.Transport{Dial: dialer.Dial}
+	if cfg.IgnoreSSL {
+		transport.TLSClientConfig = &tls.Config{InsecureSkipVerify: true}
+	}
 	client := &http.Client{Transport: transport, Timeout: cfg.Timeout}
 	up := 0.0
 	start := time.Now()

--- a/main.go
+++ b/main.go
@@ -90,7 +90,7 @@ func checkHTTP(target Target, wg *sync.WaitGroup) {
 	}
 
 	transport := &http.Transport{Dial: dialer.Dial}
-	if cfg.IgnoreSSL {
+	if cfg.InsecureSkipVerify {
 		transport.TLSClientConfig = &tls.Config{InsecureSkipVerify: true}
 	}
 	client := &http.Client{Transport: transport, Timeout: cfg.Timeout}


### PR DESCRIPTION
PR adds a config option to ignore SSL certificate validation. By default, this will be disabled. Use case is that you have a testing / pre-production site that you'd like to evaluate monitoring option but haven't gotten a full SSL/TLS cert for yet. This would allow metrics to still be collected. Currently this fails with loglines:

```
{"error":"Get \"https://www.somesite.onion\": x509: certificate signed by unknown authority","level":"warning","msg":"unable to get the url","time":"2022-08-04T08:43:05Z","url":"https://www.somesite.onion"}
```