### PR TITLE
fix: use ListenAddr config value instead of hardcoded port

### DIFF
--- a/main.go
+++ b/main.go
@@ -72,7 +72,7 @@ func main() {
 
 	prometheus.MustRegister(NewOnionCollector())
 	http.Handle("/metrics", promhttp.Handler())
-	log.Fatal(http.ListenAndServe(":9999", nil))
+	log.Fatal(http.ListenAndServe(cfg.ListenAddr, nil))
 }
 
 func checkHTTP(target Target, wg *sync.WaitGroup) {


### PR DESCRIPTION
Noted that the config value `ListenAddr` is setup, echoed out on startup, but not actually used. This replaces the hardcoded value `:9999` with the configured value (which has a default to `:9999`, so no breaking change). 