### PR TITLE
add and copy over CA certificates

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -14,11 +14,13 @@ RUN adduser \
     --uid "${UID}" \
     "${USER}"
 
+RUN apk add --no-cache ca-certificates
 
 FROM scratch
 
 COPY --from=builder /etc/passwd /etc/passwd
 COPY --from=builder /etc/group /etc/group
+COPY --from=builder /etc/ssl/certs/ca-certificates.crt /etc/ssl/certs
 COPY prometheus-onion-service-exporter /prometheus-onion-service-exporter
 
 USER appuser:appuser


### PR DESCRIPTION
Addresses issue #44, `scratch` image doesn't contain any CA cert info, so we'll need to pull that in the `builder` step and copy that into the final image. Without this, any SSL provider (really HARICA and Digicert) won't be considered trusted and the exporter will fail on x509 untrusted authority errors.