### PR TITLE
fix: linkage in dockerfile, ensure apk uses --update flag

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -14,13 +14,13 @@ RUN adduser \
     --uid "${UID}" \
     "${USER}"
 
-RUN apk add --no-cache ca-certificates
+RUN apk add --no-cache --update ca-certificates
 
 FROM scratch
 
 COPY --from=builder /etc/passwd /etc/passwd
 COPY --from=builder /etc/group /etc/group
-COPY --from=builder /etc/ssl/certs/ca-certificates.crt /etc/ssl/certs
+COPY --from=builder /etc/ssl/certs/ca-certificates.crt /etc/ssl/certs/ca-certificates.crt
 COPY prometheus-onion-service-exporter /prometheus-onion-service-exporter
 
 USER appuser:appuser


### PR DESCRIPTION
So turns out that the Dockerfile `COPY` command was incorrect in version 1.2.5 to port over the cert. Results in this error:

{"error":"Get \"https://www.REDACTED.onion\": x509: failed to load system roots and no roots provided; open /etc/ssl/certs/ca-certificates.crt: not a directory","level":"warning","msg":"unable to get the url","time":"2022-10-24T18:01:29Z","url":"https://www.REDACTED.onion"}

So this PR explicitly sets the destination and also adds the `--update` flag to ensure the latest. 