### PR TITLE
Fix GoReleaser config: include version

### DIFF
--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -1,3 +1,5 @@
+version: 2
+
 before:
   hooks:
     - go mod tidy


### PR DESCRIPTION
This should fix:

```
only version: 2 configuration files are supported, yours is version: 0, please update your configuration
```

https://github.com/systemli/prometheus-onion-service-exporter/actions/runs/22629447039/job/65575080031

No idea how to test this upfront, before merging of this PR.